### PR TITLE
Fix versioning in unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 *~
+.coverage
+tests/tmp.db

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,7 @@ python:
   - 3.3
   - 3.4
 install:
-  - pip install git+https://github.com/chfw/pyexcel-io.git  
-  - pip install git+https://github.com/chfw/pyexcel.git
-  - pip install git+https://github.com/chfw/pyexcel-webio.git
-  - pip install git+https://github.com/chfw/pyexcel-xls.git
-  - pip install git+https://github.com/chfw/pyexcel-xlsx.git 
-  - pip install git+https://github.com/T0ha/ezodf.git
   - if [[ $TRAVIS_PYTHON_VERSION == "2.6" ]]; then pip install weakrefset; fi
-  - pip install git+https://github.com/chfw/pyexcel-ods3.git 
   - pip install -r tests/requirements.txt --use-mirrors
 script:
   make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
   - 3.5
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == "2.6" ]]; then pip install weakrefset; fi
-  - pip install -r tests/requirements.txt --use-mirrors
+  - pip install -r tests/requirements.txt
 script:
   make test
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - 2.7
   - 3.3
   - 3.4
+  - 3.5
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == "2.6" ]]; then pip install weakrefset; fi
   - pip install -r tests/requirements.txt --use-mirrors

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,14 @@ dependencies = [
     'pyexcel-webio>=0.0.3',
     'Flask>=0.10.1'
 ]
+extras = {
+    'xls': ['pyexcel-xls==0.0.7'],
+    'xlsx': ['pyexcel-xlsx==0.0.7'],
+    'ods3': [
+        'pyexcel-ods3==0.0.8',
+        'git+https://github.com/T0ha/ezodf.git@2c69103e6c0715adb0e36562cb2e6325fd776112#egg=ezodf-master',
+    ],
+}
 
 setup(
     name='Flask-Excel',
@@ -22,6 +30,7 @@ setup(
     url="https://github.com/chfw/Flask-Excel",
     description='A flask extension that provides one application programming interface to read and write data in different excel file formats',
     install_requires=dependencies,
+    extras_require=extras,
     packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
     include_package_data=True,
     long_description=README_txt,

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,11 @@ dependencies = [
     'Flask>=0.10.1'
 ]
 extras = {
-    'xls': ['pyexcel-xls==0.0.7'],
-    'xlsx': ['pyexcel-xlsx==0.0.7'],
+    'xls': ['pyexcel-xls>=0.0.7'],
+    'xlsx': ['pyexcel-xlsx>=0.0.7'],
     'ods3': [
-        'pyexcel-ods3==0.0.8',
-        'git+https://github.com/T0ha/ezodf.git@2c69103e6c0715adb0e36562cb2e6325fd776112#egg=ezodf-master',
+        'pyexcel-ods3>=0.0.8',
+        'https://github.com/T0ha/ezodf/archive/2c69103e6c0715adb0e36562cb2e6325fd776112.zip',
     ],
 }
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,6 +5,11 @@ rednose
 nose-cov
 python-coveralls
 coverage
-pyexcel-xls
-pyexcel-xlsx
+-e git+git@github.com:chfw/pyexcel.git@040cd392ec40069ac1a0f6df755694c8216366d8#egg=pyexcel-master
+pyexcel-io==0.0.8
+pyexcel-ods3==0.0.8
+pyexcel-webio==0.0.3
+pyexcel-xls==0.0.7
+pyexcel-xlsx==0.0.7
+-e git+https://github.com/T0ha/ezodf.git@2c69103e6c0715adb0e36562cb2e6325fd776112#egg=ezodf-master
 lxml

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,7 +5,7 @@ rednose
 nose-cov
 python-coveralls
 coverage
--e git+git@github.com:chfw/pyexcel.git@040cd392ec40069ac1a0f6df755694c8216366d8#egg=pyexcel-master
+-e git+https://github.com/chfw/pyexcel.git@040cd392ec40069ac1a0f6df755694c8216366d8#egg=pyexcel-master
 pyexcel-io==0.0.8
 pyexcel-ods3==0.0.8
 pyexcel-webio==0.0.3

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,11 +5,11 @@ rednose
 nose-cov
 python-coveralls
 coverage
--e git+https://github.com/chfw/pyexcel.git@040cd392ec40069ac1a0f6df755694c8216366d8#egg=pyexcel-master
-pyexcel-io==0.0.8
-pyexcel-ods3==0.0.8
-pyexcel-webio==0.0.3
-pyexcel-xls==0.0.7
-pyexcel-xlsx==0.0.7
--e git+https://github.com/T0ha/ezodf.git@2c69103e6c0715adb0e36562cb2e6325fd776112#egg=ezodf-master
+pyexcel>=0.1.7
+pyexcel-io>=0.0.8
+pyexcel-ods3>=0.0.8
+pyexcel-webio>=0.0.3
+pyexcel-xls>=0.0.7
+pyexcel-xlsx>=0.0.7
+https://github.com/T0ha/ezodf/archive/2c69103e6c0715adb0e36562cb2e6325fd776112.zip
 lxml


### PR DESCRIPTION
The unit tests don't run out of the box because of some inconsistencies between what's hard-coded in .travis.yml. Frustrating trying to figure out which versions actually work together, but I figured it out.